### PR TITLE
Feature/#2 fix function to register employee information

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,5 +31,15 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
 
+Layout/LineLength:
+  Max: 125
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
+Metrics/MethodLength:
+  Max: 15
+
 Style/FrozenStringLiteralComment:
   Enabled: false

--- a/app/assets/stylesheets/employees.scss
+++ b/app/assets/stylesheets/employees.scss
@@ -53,26 +53,43 @@
     }
 
     input {
-      width: 150px;
+      width: 202px;
       margin-right: 20px;
       margin-top: 5px;
     }
 
-    input[type="checkbox"]{
-      margin: 12px 0 0 -227px;
+    .input_long {
+      width: 300px;
+      height: 22px;
+      margin-right: 20px;
+      margin-top: 5px;
     }
 
     select {
       height: 29px;
-      width: 158px;
+      width: 210px;
       padding-left: 12px;
       margin-top: 5px;
       border-radius: 6px;
     }
 
+    .select_short {
+      height: 29px;
+      width: 70px;
+      padding-left: 12px;
+      margin-top: 5px;
+      border-radius: 6px;
+    }
+  }
+
+  .form_group_checkbox {
+    display: flex;
+    line-height: 2.4em;
+
     .checkbox_label {
       width: fit-content;
       margin-left: 30px;
+      margin-left: 20px;
     }
   }
 

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -13,8 +13,6 @@ class EmployeesController < ApplicationController
   def create
     @employee = Employee.new(employee_params)
 
-    add_params
-
     if @employee.save
       redirect_to employees_url, notice: "社員「#{@employee.last_name} #{@employee.first_name}」を登録しました。"
     else
@@ -26,8 +24,6 @@ class EmployeesController < ApplicationController
   end
 
   def update
-    add_params
-
     if @employee.update(employee_params)
       redirect_to employees_url, notice: "社員「#{@employee.last_name} #{@employee.first_name}」を更新しました。"
     else
@@ -48,7 +44,7 @@ class EmployeesController < ApplicationController
   private
 
   def employee_params
-    params.require(:employee).permit(:number, :last_name, :first_name, :account, :password, :department_id, :office_id, :employee_info_manage_auth)
+    params.require(:employee).permit(:number, :last_name, :first_name, :account, :password, :email, :date_of_joining, :department_id, :office_id, :employee_info_manage_auth, :news_posting_auth)
   end
 
   def set_employee
@@ -58,16 +54,6 @@ class EmployeesController < ApplicationController
   def set_form_option
     @departments = Department.all
     @offices = Office.all
-  end
-
-  # 現在、メールアドレスと入社日は入力できないため、ここで追加しています。
-  def add_params
-    unless @employee.email
-      @employee.email = 'sample@example.com'
-    end
-    unless @employee.date_of_joining
-      @employee.date_of_joining = Date.today
-    end
   end
 
   def sort_column

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -8,6 +8,8 @@ class Employee < ApplicationRecord
   validates :first_name, presence: true
   validates :account, presence: true, uniqueness: true
   validates :password, presence: true
+  validates :email, presence: true
+  validates :date_of_joining, presence: true
 
   scope :active, -> {
     where(deleted_at: nil)

--- a/app/views/employees/_form.html.slim
+++ b/app/views/employees/_form.html.slim
@@ -20,12 +20,21 @@
       = f.label :password
       = f.password_field :password
     .form_group
+      = f.label :email
+      = f.email_field :email, class: 'input_long'
+    .form_group
+      = f.label :date_of_joining
+      = f.date_select :date_of_joining, {start_year: 2012, end_year: Time.zone.now.year, include_blank: true}, {class: 'select_short'}
+    .form_group
       = f.label :department_id
       = f.collection_select(:department_id, @departments, :id, :name)
     .form_group
       = f.label :office_id
       = f.collection_select(:office_id, @offices, :id, :name)
-    .form_group
-      = f.label :employee_info_manage_auth, class: 'checkbox_label'
+    .form_group_checkbox
       = f.check_box :employee_info_manage_auth, :as => :boolean
-    = f.submit '保存'
+      = f.label :employee_info_manage_auth, class: 'checkbox_label'
+    .form_group_checkbox
+      = f.check_box :news_posting_auth, :as => :boolean
+      = f.label :news_posting_auth, class: 'checkbox_label'
+    = f.submit '保存', id: 'submit_save'

--- a/app/views/employees/new.html.slim
+++ b/app/views/employees/new.html.slim
@@ -1,1 +1,1 @@
-= render partial: 'form', locals: { employee: @employee, departments: @departments, offices: @offices }
+= render partial: 'form', locals: { employee: @employee }

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -12,4 +12,4 @@
         = flash[:alert]
     .row-center
       p
-        = f.submit 'ログイン',class: 'form-submit'
+        = f.submit 'ログイン',class: 'form-submit',id: 'submit_login'

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,7 @@ module NewsAndEmployeeIntroduction
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Tokyo'
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Don't generate system test files.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,7 +7,7 @@ ja:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
         required: を入力してください
-        blank: を入力してください
+        blank: が入力されていません
         too_long: は%{count}文字以内で入力してください
         too_short: は%{count}文字以上で入力してください
         taken: はすでに存在します
@@ -28,10 +28,32 @@ ja:
         first_name: 氏名（名）
         account: アカウント
         password: パスワード
-        e_mail: メールアドレス
+        email: メールアドレス
         date_of_joining: 入社年月日
         department_id: 部署
         office_id: オフィス
         employee_info_manage_auth: 社員情報管理権限
+        news_posting_auth: お知らせ投稿権限
       profile:
         profile: プロフィール
+  date:
+    month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  errors:
+    format: "%{attribute}%{message}"

--- a/db/migrate/20220912143216_add_news_posting_auth_to_employees.rb
+++ b/db/migrate/20220912143216_add_news_posting_auth_to_employees.rb
@@ -1,0 +1,5 @@
+class AddNewsPostingAuthToEmployees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :employees, :news_posting_auth, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_20_112406) do
+ActiveRecord::Schema.define(version: 2022_09_12_143216) do
 
   create_table "departments", force: :cascade do |t|
     t.string "name", null: false
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2021_10_20_112406) do
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "news_posting_auth", default: false, null: false
     t.index ["department_id"], name: "index_employees_on_department_id"
     t.index ["office_id"], name: "index_employees_on_office_id"
   end

--- a/spec/factories/departments.rb
+++ b/spec/factories/departments.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :general_affairs, class: Department do
+    id { '0' }
+    name { '総務部' }
+  end
+end

--- a/spec/factories/employees.rb
+++ b/spec/factories/employees.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :employee do
+  end
+end

--- a/spec/factories/employees.rb
+++ b/spec/factories/employees.rb
@@ -1,4 +1,15 @@
 FactoryBot.define do
   factory :employee do
+    number { '1' }
+    last_name { '太郎' }
+    first_name { '山田' }
+    account { 'yamada' }
+    password  { 'hogehoge' }
+    email { 'yamada@aaa.com' }
+    date_of_joining { '1991/4/1' }
+    department_id { '0' }
+    office_id { '0' }
+    employee_info_manage_auth { 'TRUE' }
+    news_posting_auth { 'TRUE' }
   end
 end

--- a/spec/factories/offices.rb
+++ b/spec/factories/offices.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :tokyo, class: Office do
+    id { '0' }
+    name { '東京' }
+  end
+end

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -1,6 +1,56 @@
 require 'rails_helper'
 
 RSpec.describe Employee, type: :model do
+  before do
+    @department = create(:general_affairs)
+    @office = create(:tokyo)
+  end
+
+  it 'is valid with a number, last_name, first_name, account, password, email, date_of_joining, department, and office' do
+    employee = Employee.new(
+      number: '1',
+      last_name: '山田',
+      first_name: '太郎',
+      account: 'yamada',
+      password: 'hogehoge',
+      email: 'yamada@example.co.jp',
+      date_of_joining: '1991/4/1',
+      department: @department,
+      office: @office
+    )
+    expect(employee).to be_valid
+  end
+
+  it 'is invalid without a number' do
+    employee = Employee.new(number: nil)
+    employee.valid?
+    expect(employee.errors).to be_of_kind(:number, :blank)
+  end
+
+  it 'is invalid without a last_name' do
+    employee = Employee.new(last_name: nil)
+    employee.valid?
+    expect(employee.errors).to be_of_kind(:last_name, :blank)
+  end
+
+  it 'is invalid without a first_name' do
+    employee = Employee.new(first_name: nil)
+    employee.valid?
+    expect(employee.errors).to be_of_kind(:first_name, :blank)
+  end
+
+  it 'is invalid without an account' do
+    employee = Employee.new(account: nil)
+    employee.valid?
+    expect(employee.errors).to be_of_kind(:account, :blank)
+  end
+
+  it 'is invalid without a password' do
+    employee = Employee.new(password: nil)
+    employee.valid?
+    expect(employee.errors).to be_of_kind(:password, :blank)
+  end
+
   it 'is invalid without an email' do
     employee = Employee.new(email: nil)
     employee.valid?
@@ -11,5 +61,17 @@ RSpec.describe Employee, type: :model do
     employee = Employee.new(date_of_joining: nil)
     employee.valid?
     expect(employee.errors).to be_of_kind(:date_of_joining, :blank)
+  end
+
+  it 'is invalid without a department' do
+    employee = Employee.new(department: nil)
+    employee.valid?
+    expect(employee.errors).to be_of_kind(:department, :blank)
+  end
+
+  it 'is invalid without an office' do
+    employee = Employee.new(office: nil)
+    employee.valid?
+    expect(employee.errors).to be_of_kind(:office, :blank)
   end
 end

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Employee, type: :model do
+  it 'is invalid without an email' do
+    employee = Employee.new(email: nil)
+    employee.valid?
+    expect(employee.errors).to be_of_kind(:email, :blank)
+  end
+
+  it 'is invalid without a date_of_joining' do
+    employee = Employee.new(date_of_joining: nil)
+    employee.valid?
+    expect(employee.errors).to be_of_kind(:date_of_joining, :blank)
+  end
+end

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -1,0 +1,12 @@
+module LoginSupport
+  def sign_in_as(user)
+    visit login_path
+    fill_in 'employees[account]', with: user.account
+    fill_in 'employees[password]', with: user.password
+    find('#submit_login').click
+  end
+end
+
+RSpec.configure do |config|
+  config.include LoginSupport
+end

--- a/spec/support/register_support.rb
+++ b/spec/support/register_support.rb
@@ -1,0 +1,22 @@
+module RegisterSupport
+  def register_employee_information
+    fill_in 'employee[number]', with: '2'
+    fill_in 'employee[last_name]', with: '太郎'
+    fill_in 'employee[first_name]', with: '佐藤'
+    fill_in 'employee[account]', with: 'satou'
+    fill_in 'employee[password]', with: 'hogehoge'
+    fill_in 'employee[email]', with: 'satou@aaa.com'
+    select '2012', from: 'employee[date_of_joining(1i)]'
+    select '4月', from: 'employee[date_of_joining(2i)]'
+    select '1', from: 'employee[date_of_joining(3i)]'
+    select '総務部', from: 'employee[department_id]'
+    select '東京', from: 'employee[office_id]'
+    check 'employee[employee_info_manage_auth]'
+    check 'employee[news_posting_auth]'
+    find('#submit_save').click
+  end
+end
+
+RSpec.configure do |config|
+  config.include RegisterSupport
+end

--- a/spec/system/register_employee_information_spec.rb
+++ b/spec/system/register_employee_information_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe '社員情報登録', type: :system do
+  before do
+    department = create(:general_affairs)
+    office = create(:tokyo)
+    user = create(:employee, department: department, office: office)
+    sign_in_as user
+    visit new_employee_path
+  end
+
+  describe '・社員情報の登録ができる。' do
+    it 'is success!' do
+      expect { register_employee_information }.to change(Employee, :count).by(1)
+    end
+  end
+
+  describe '・保存ボタンをクリックしたとき、バリデーションチェックを行う。' do
+    before do
+      find('#submit_save').click
+    end
+
+    scenario "・メールアドレス：入力されているか？：'メールアドレスが入力されていません'" do
+      expect(page).to have_selector '.employee_form ul li', text: 'メールアドレスが入力されていません'
+    end
+
+    scenario "・入社年月日：入力されているか？：'入社年月日が入力されていません'" do
+      expect(page).to have_selector '.employee_form ul li', text: '入社年月日が入力されていません'
+    end
+  end
+
+  describe '・登録した後、一覧画面に遷移する。' do
+    before do
+      register_employee_information
+    end
+
+    it 'is success!' do
+      expect(current_path).to eq employees_path
+    end
+  end
+end

--- a/spec/system/register_employee_information_spec.rb
+++ b/spec/system/register_employee_information_spec.rb
@@ -20,6 +20,26 @@ RSpec.describe '社員情報登録', type: :system do
       find('#submit_save').click
     end
 
+    scenario "・社員番号：入力されているか？：'社員番号が入力されていません'" do
+      expect(page).to have_selector '.employee_form ul li', text: '社員番号が入力されていません'
+    end
+
+    scenario "・氏名（姓）：入力されているか？：'氏名（姓）が入力されていません'" do
+      expect(page).to have_selector '.employee_form ul li', text: '氏名（姓）が入力されていません'
+    end
+
+    scenario "・氏名（名）：入力されているか？：'氏名（名）が入力されていません'" do
+      expect(page).to have_selector '.employee_form ul li', text: '氏名（名）が入力されていません'
+    end
+
+    scenario "・アカウント：入力されているか？：'アカウントが入力されていません'" do
+      expect(page).to have_selector '.employee_form ul li', text: 'アカウントが入力されていません'
+    end
+
+    scenario "・パスワード：入力されているか？：'パスワードが入力されていません'" do
+      expect(page).to have_selector '.employee_form ul li', text: 'パスワードが入力されていません'
+    end
+
     scenario "・メールアドレス：入力されているか？：'メールアドレスが入力されていません'" do
       expect(page).to have_selector '.employee_form ul li', text: 'メールアドレスが入力されていません'
     end


### PR DESCRIPTION
# #2社員情報登録機能を修正
## [add] 「お知らせ投稿権限」カラムを追加
- [add] db/migrate/20220912143216_add_news_posting_auth_to_employees.rbファイルを追加
## [add] employeeモデルにメールアドレスと入社年月日のバリデーションを追加
- [fix] app/models/employee.rbファイルを修正
### [fix] テストコードを追加
- [add] spec/models/employee_spec.rbファイルを追加
## [fix] 社員情報登録機能を修正(登録項目を追加するため)
- [fix] app/controllers/employees_controller.rbファイルを修正
### [fix] viewを修正
- [fix] scssファイルを修正
- [fix] views/employees/new.html.slimファイルを修正
    - [fix] views/employees/_form.html.slimファイルの修正
        - [fix] config/application.rbファイルを修正(TimeWithZoneメソッドを使用するため)
        - [fix] config/locales/ja.ymlファイルを修正(見本とテキストを一致させるため)
### [add] テストコードを追加
- [add] register_employee_information_spec.rbファイルを追加
    - [add] login_support.rbファイルを追加
        - [fix] views/sessions/new.html.slimファイルを修正(要素にidを指定し、正確なテストを実行するため)
    - [add] register_support.rbファイルを追加
#### [add] ファクトリーを追加
- [add] spec/factories/employees.rbファイルを追加
- [add] spec/factories/employees.rbファイルを追加
- [add] spec/factories/offices.rbファイルを追加
## [add] もともと実装済の機能に対してテストを追加
- [fix] spec/models/employee_spec.rbファイルを修正
- [fix] register_employee_information_spec.rbファイルを修正
## [fix] .rubocop.ymlファイルを修正(不要なアラートが表示されないようにするため)